### PR TITLE
Github Actions: Enable yarn cache; Use official Docker actions

### DIFF
--- a/.github/workflows/build-test-and-deploy.yml
+++ b/.github/workflows/build-test-and-deploy.yml
@@ -41,11 +41,11 @@ jobs:
     - name: Login to DockerHub
       uses: docker/login-action@v1 
       with:
-        username: engagementteamci
+        username: ${{ secrets.DOCKERHUBUSERNAME }}
         password: ${{ secrets.DOCKERHUBPASSWORD }}
         
     - name: Publish Docker
       uses: docker/build-push-action@v2
       with:
         push: true
-        tags: engagementteamci/node-addition-service:github-actions
+        tags: ${{ secrets.DOCKERHUBUSERNAME }}/node-addition-service:github-actions

--- a/.github/workflows/build-test-and-deploy.yml
+++ b/.github/workflows/build-test-and-deploy.yml
@@ -45,5 +45,3 @@ jobs:
       with:
         push: true
         tags: ${{ secrets.DOCKERHUBUSERNAME }}/node-addition-service:github-actions
-        cache-from: type=gha
-        cache-to: type=gha,mode=max

--- a/.github/workflows/build-test-and-deploy.yml
+++ b/.github/workflows/build-test-and-deploy.yml
@@ -24,6 +24,10 @@ jobs:
       uses: actions/setup-node@v1
       with:
         node-version: ${{ matrix.node-version }}
+    - uses: actions/cache@v2
+      with:
+        path: node_modules
+        key: node-deps-v1-${{ hashFiles('**/yarn.lock') }}
     - run: yarn install --frozen-lockfile
     - run: yarn test
     

--- a/.github/workflows/build-test-and-deploy.yml
+++ b/.github/workflows/build-test-and-deploy.yml
@@ -30,25 +30,22 @@ jobs:
         key: node-deps-v1-${{ hashFiles('**/yarn.lock') }}
     - run: yarn install --frozen-lockfile
     - run: yarn test
-    
+
   deploy:
     needs: build-and-test
     runs-on: ubuntu-latest
 
-    strategy:
-      matrix:
-        node-version: [14.x]
-        # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
-
     steps:
     - uses: actions/checkout@v2
-    - name: Publish Docker
-      # You may pin to the exact commit or the version.
-      # uses: elgohr/Publish-Docker-Github-Action@f7aca2fea76a5218f3c76cd5933c3ba1d8008774
-      uses: elgohr/Publish-Docker-Github-Action@3.02
+
+    - name: Login to DockerHub
+      uses: docker/login-action@v1 
       with:
-        name: engagementteamci/node-addition-service
         username: engagementteamci
         password: ${{ secrets.DOCKERHUBPASSWORD }}
-        default_branch: main
-        tags: "github-actions"
+        
+    - name: Publish Docker
+      uses: docker/build-push-action@v2
+      with:
+        push: true
+        tags: engagementteamci/node-addition-service:github-actions

--- a/.github/workflows/build-test-and-deploy.yml
+++ b/.github/workflows/build-test-and-deploy.yml
@@ -34,15 +34,16 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-
-    - name: Login to DockerHub
-      uses: docker/login-action@v1 
+    - uses: docker/setup-buildx-action@v1
+    - uses: docker/login-action@v1 
       with:
         username: ${{ secrets.DOCKERHUBUSERNAME }}
         password: ${{ secrets.DOCKERHUBPASSWORD }}
-        
+
     - name: Publish Docker
       uses: docker/build-push-action@v2
       with:
         push: true
         tags: ${{ secrets.DOCKERHUBUSERNAME }}/node-addition-service:github-actions
+        cache-from: type=gha
+        cache-to: type=gha,mode=max

--- a/.github/workflows/build-test-and-deploy.yml
+++ b/.github/workflows/build-test-and-deploy.yml
@@ -34,8 +34,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - uses: docker/setup-buildx-action@v1
-    - uses: docker/login-action@v1 
+    - uses: docker/login-action@v1
       with:
         username: ${{ secrets.DOCKERHUBUSERNAME }}
         password: ${{ secrets.DOCKERHUBPASSWORD }}

--- a/.github/workflows/build-test-and-deploy.yml
+++ b/.github/workflows/build-test-and-deploy.yml
@@ -21,13 +21,10 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@v2
       with:
         node-version: ${{ matrix.node-version }}
-    - uses: actions/cache@v2
-      with:
-        path: node_modules
-        key: node-deps-v1-${{ hashFiles('**/yarn.lock') }}
+        cache: yarn
     - run: yarn install --frozen-lockfile
     - run: yarn test
 


### PR DESCRIPTION
I was comparing the circleci and github actions pipelines and saw that they aren't doing the same things, so I figured I'd bring some parity. The two main points are:

1. Enable the github actions yarn cache. Github Actions caches yarn's package-cache, instead of `node_modules/` like the CircleCI pipeline, so these aren't exactly equal in effect. But it's the default option from each vendor once you enable Yarn caching.
2. Use official https://github.com/docker/build-push-action instead of the third-party https://github.com/)elgohr/Publish-Docker-Github-Action. The CircleCI pipeline is also using an official action for Docker, just from CircleCI instead of from Docker.

With these two changes I'm seeing execution times from 45-60s instead of 65-80s. In order to test this I parameterized the Dockerhub user. I can revert that bit easily if requested.

Also, the CircleCI pipeline doesn't have any nodejs matrix (in fact it's always using `lts` which is surely newer than the 14.x that the Dockerfile uses). So I removed the nodejs matrix from the `publish` job but left it on the `test` job since usually only one nodejs version is used for a given project's official images.
